### PR TITLE
Execute cdxgen commands within the repo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}",
+            "env": {},
+            "args": ["analyze", "-c", "testConfig.json"],
+            "showLog": true
+        }
+    ]
+}


### PR DESCRIPTION
Executing the cdxgen commands within the local repo path enables deterministic behavior for analyzing java projects.