### PR TITLE
Improve upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ analyze
 #### Upload
 The upload command can be used to upload the sbom files resulting from the analyze command. This can be useful in restricted network environments. You can use a two stage pipeline to first analyze the projects on a cloud agent and use a self hosted agent to upload the reuslting sboms.
 
-It is important, that Central Cyclone can only upload sboms created by Central Cyclone. Otherwise, Central Cyclone is not able to match the sbom file with the corresponding project.
+It is important, that Central Cyclone can only upload sboms created by Central Cyclone with the same version. Central Cyclon does not save the *raw* sbom as json but wrapped with some meta information such as the DependencyTrack Project Id.
 
 ```
 upload

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -36,6 +36,7 @@ func (a CdxgenAnalyzer) AnalyzeProject(repo workspace.ClonedRepo, target config.
 	}
 
 	bytes, err := os.ReadFile(sbomFilePath)
+	sbomstring := string(bytes)
 	os.Remove(sbomFilePath)
 
 	if err != nil {
@@ -43,9 +44,8 @@ func (a CdxgenAnalyzer) AnalyzeProject(repo workspace.ClonedRepo, target config.
 		return sbom.Sbom{}, fmt.Errorf("failed to read sbom file: %v", err)
 	}
 	return sbom.Sbom{
-		ProjectId:         target.ProjectId,
-		ProjectType:       target.Type,
-		ProjectFolderName: repo.FolderName,
-		Data:              bytes,
+		ProjectId:   target.ProjectId,
+		ProjectType: target.Type,
+		Data:        sbomstring,
 	}, nil
 }

--- a/internal/sbom/sbom.go
+++ b/internal/sbom/sbom.go
@@ -1,8 +1,7 @@
 package sbom
 
 type Sbom struct {
-	ProjectId         string
-	ProjectType       string
-	ProjectFolderName string
-	Data              []byte
+	ProjectId   string `json:"projectId"`
+	ProjectType string `json:"projectType"`
+	Data        string `json:"data"`
 }

--- a/internal/upload/dtUploader.go
+++ b/internal/upload/dtUploader.go
@@ -45,7 +45,7 @@ func (uploader DependencyTrackUploader) UploadSBOM(sbom sbom.Sbom) error {
 }
 
 func getEncodedSbom(sbom sbom.Sbom) (string, error) {
-	encodedSbom := base64.StdEncoding.EncodeToString(sbom.Data)
+	encodedSbom := base64.StdEncoding.EncodeToString([]byte(sbom.Data))
 	return encodedSbom, nil
 }
 

--- a/internal/workspace/clonedrepo.go
+++ b/internal/workspace/clonedrepo.go
@@ -1,7 +1,6 @@
 package workspace
 
 type ClonedRepo struct {
-	Path       string
-	FolderName string
-	RepoUrl    string
+	Path    string
+	RepoUrl string
 }

--- a/internal/workspace/sbommapping.go
+++ b/internal/workspace/sbommapping.go
@@ -4,31 +4,15 @@ import (
 	"central-cyclone/internal/sbom"
 	"fmt"
 	"path/filepath"
-	"strings"
 )
 
 type SBOMNamer interface {
 	GenerateSBOMPath(sbomsDir string, sbom sbom.Sbom) string
-	ParseFilename(filename string) (repoFolderName string, projectType string, err error)
 }
 
 type DefaultSBOMNamer struct{}
 
 func (n DefaultSBOMNamer) GenerateSBOMPath(sbomsDir string, sbom sbom.Sbom) string {
-	sbomFileName := fmt.Sprintf("%s_sbom_%s.json", sbom.ProjectFolderName, sbom.ProjectType)
+	sbomFileName := fmt.Sprintf("sbom_%s.json", sbom.ProjectId)
 	return filepath.Join(sbomsDir, sbomFileName)
-}
-
-func (n DefaultSBOMNamer) ParseFilename(fileName string) (repoFolderName string, projectType string, err error) {
-	fileNameWithoutExt := strings.TrimSuffix(fileName, ".json")
-
-	parts := strings.Split(fileNameWithoutExt, "_sbom_")
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid filename format: %s expected format: org_repo_sbom_type.json", fileName)
-	}
-
-	folderName := parts[0]
-	projectType = parts[1]
-
-	return folderName, projectType, nil
 }

--- a/internal/workspace/sbommapping_test.go
+++ b/internal/workspace/sbommapping_test.go
@@ -10,103 +10,12 @@ func TestDefaultSBOMNamer_GenerateSBOMPath(t *testing.T) {
 	namer := DefaultSBOMNamer{}
 	sbomsDir := "/path/to/sboms"
 	sbom := sbom.Sbom{
-		ProjectFolderName: "org_repo",
-		ProjectType:       "go",
+		ProjectId:   "org_repo",
+		ProjectType: "go",
 	}
 	got := namer.GenerateSBOMPath(sbomsDir, sbom)
-	want := filepath.Join(sbomsDir, "org_repo_sbom_go.json")
+	want := filepath.Join(sbomsDir, "sbom_org_repo.json")
 	if got != want {
 		t.Errorf("GenerateSBOMPath() = %q, want %q", got, want)
-	}
-}
-
-func TestDefaultSBOMNamer_ParseFilename(t *testing.T) {
-	tests := []struct {
-		name            string
-		filename        string
-		wantFolderName  string
-		wantProjectType string
-		wantErr         bool
-	}{
-		{
-			name:            "valid filename with go project",
-			filename:        "org_repo_sbom_go.json",
-			wantFolderName:  "org_repo",
-			wantProjectType: "go",
-			wantErr:         false,
-		},
-		{
-			name:            "valid filename with npm project",
-			filename:        "my_project_sbom_npm.json",
-			wantFolderName:  "my_project",
-			wantProjectType: "npm",
-			wantErr:         false,
-		},
-		{
-			name:            "valid filename with python project",
-			filename:        "data_science_sbom_python.json",
-			wantFolderName:  "data_science",
-			wantProjectType: "python",
-			wantErr:         false,
-		},
-		{
-			name:            "filename with underscore in folder name",
-			filename:        "my_org_my_repo_sbom_java.json",
-			wantFolderName:  "my_org_my_repo",
-			wantProjectType: "java",
-			wantErr:         false,
-		},
-		{
-			name:            "missing .json extension",
-			filename:        "org_repo_sbom_go",
-			wantFolderName:  "org_repo",
-			wantProjectType: "go",
-			wantErr:         false,
-		},
-		{
-			name:            "invalid format - missing _sbom_ separator",
-			filename:        "org_repo_go.json",
-			wantFolderName:  "",
-			wantProjectType: "",
-			wantErr:         true,
-		},
-		{
-			name:            "invalid format - multiple _sbom_ separators",
-			filename:        "org_repo_sbom_type_sbom_extra.json",
-			wantFolderName:  "",
-			wantProjectType: "",
-			wantErr:         true,
-		},
-		{
-			name:            "invalid format - only filename with no structure",
-			filename:        "random.json",
-			wantFolderName:  "",
-			wantProjectType: "",
-			wantErr:         true,
-		},
-		{
-			name:            "empty filename",
-			filename:        "",
-			wantFolderName:  "",
-			wantProjectType: "",
-			wantErr:         true,
-		},
-	}
-
-	namer := DefaultSBOMNamer{}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotFolderName, gotProjectType, err := namer.ParseFilename(tt.filename)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseFilename() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if gotFolderName != tt.wantFolderName {
-				t.Errorf("ParseFilename() folderName = %q, want %q", gotFolderName, tt.wantFolderName)
-			}
-			if gotProjectType != tt.wantProjectType {
-				t.Errorf("ParseFilename() projectType = %q, want %q", gotProjectType, tt.wantProjectType)
-			}
-		})
 	}
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"central-cyclone/internal/gittool"
 	"central-cyclone/internal/sbom"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -47,9 +48,8 @@ func (w localWorkspace) CloneRepoToWorkspace(repoUrl string) (ClonedRepo, error)
 		return ClonedRepo{}, fmt.Errorf("failed to clone repo: %w", err)
 	}
 	return ClonedRepo{
-		Path:       targetDir,
-		FolderName: folderName,
-		RepoUrl:    repoUrl,
+		Path:    targetDir,
+		RepoUrl: repoUrl,
 	}, nil
 }
 
@@ -66,7 +66,11 @@ func (w localWorkspace) Clear() error {
 
 func (w localWorkspace) SaveSbom(sbom sbom.Sbom) error {
 	sbomPath := w.namer.GenerateSBOMPath(w.sbomsPath, sbom)
-	if err := w.fs.WriteFile(sbomPath, sbom.Data); err != nil {
+	data, err := json.Marshal(sbom)
+	if err != nil {
+		return fmt.Errorf("failed to marshal SBOM: %w", err)
+	}
+	if err := w.fs.WriteFile(sbomPath, data); err != nil {
 		return fmt.Errorf("failed to save SBOM to %s: %w", sbomPath, err)
 	}
 	slog.Info("💾 Saved SBOM", "path", sbomPath)


### PR DESCRIPTION
Central Cyclone will now save custom json files that contain some metadata such as the DependencyTrack Project Id. Thus, filenames of the sboms are irrelevant now and can be changed.